### PR TITLE
Add "db" as a zone file extension

### DIFF
--- a/Bind Zone Files.json-tmlanguage
+++ b/Bind Zone Files.json-tmlanguage
@@ -1,6 +1,6 @@
 { "name": "Bind Zone Files",
   "scopeName": "text.zone_file",
-  "fileTypes": ["zone"],
+  "fileTypes": ["zone", "db"],
   "patterns": [
     { "match": ";.*",
       "name": "comment.line.semicolon.zone_file"

--- a/Bind Zone Files.tmlanguage
+++ b/Bind Zone Files.tmlanguage
@@ -5,6 +5,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>zone</string>
+		<string>db</string>
 	</array>
 	<key>name</key>
 	<string>Bind Zone Files</string>


### PR DESCRIPTION
"db" is a fairly common file extension for zone files (and also happens to be the one I use at work). These changes will open ".db" files with DNS syntax highlighting.
