### PR TITLE
Change to highlight comments at end of regular lines

### DIFF
--- a/Bind Zone Files.tmlanguage
+++ b/Bind Zone Files.tmlanguage
@@ -50,7 +50,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>([A-Za-z0-9_.-]*)\s+([0-9A-Za-z]*)\s+([I|i][N|n]\s+[A-Za-z]+)\s+(.*)\(</string>
+			<string>([A-Za-z0-9_.-]*)\s+([0-9A-Za-z]*)\s+([I|i][N|n]\s+[A-Za-z]+)\s+(.*)\s*(;.*)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>2</key>
@@ -68,9 +68,14 @@
 					<key>name</key>
 					<string>string.quoted.single.resource.address.zone_file</string>
 				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>comment.line.semicolon.zone_file</string>
+				</dict>
 			</dict>
 			<key>end</key>
-			<string>\)</string>
+			<string></string>
 			<key>name</key>
 			<string>string.quoted.single.address.zone_file</string>
 			<key>patterns</key>


### PR DESCRIPTION
Currently, if you have a regular DNS entry with a comment at the end, the comment is highlighted as part of the DNS record, not a comment. This change highlights comments that are at the end of a line that contains a DNS record.

I haven't tested with many files and haven't written any ST2 syntax highlighting before, so you might want to test this before merging.
