### PR TITLE
Highlight comments after DNS records correctly

### DIFF
--- a/Bind Zone Files.tmlanguage
+++ b/Bind Zone Files.tmlanguage
@@ -103,7 +103,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>([A-Za-z0-9_.-]*)\s+([0-9A-Za-z]*)\s+([I|i][N|n]\s+[A-Za-z]+)\s+(.*)</string>
+			<string>([A-Za-z0-9_.-]*)\s+([0-9A-Za-z]*)\s+([I|i][N|n]\s+[A-Za-z]+)\s+([^;]*)</string>
 			<key>name</key>
 			<string>string.quoted.single.address.zone_file</string>
 		</dict>


### PR DESCRIPTION
Inspired by @cdodd's work at PR https://github.com/sixty4k/st2-zonefile/pull/3.

This stops "eating" a DNS record when a finishing semicolon is found which is then free to be colored by the first rule of this language.
