### PR TITLE
Support resource record types with names containing numbers

### DIFF
--- a/Bind Zone Files.json-tmLanguage
+++ b/Bind Zone Files.json-tmLanguage
@@ -18,7 +18,7 @@
     { "match": "\\d+(H|h|D|d|W|w|M|m|Y|y)",
       "name": "variable.other.timeunit.zone_file"
     },
-    { "begin": "([A-Za-z0-9_.-]*)\\s+(?:([0-9A-Za-z]*)\\s+)?([I|i][N|n]\\s+[A-Za-z]+)\\s+(.*)\\(",
+    { "begin": "([A-Za-z0-9_.-]*)\\s+(?:([0-9A-Za-z]*)\\s+)?([I|i][N|n]\\s+[A-Za-z0-9]+)\\s+(.*)\\(",
       "beginCaptures": {
           "2": { "name": "variable.other.timeunit.zone_file"},
           "3": { "name": "keyword.resourcetype.zone_file" },
@@ -32,7 +32,7 @@
       "end": "\\)",
       "name": "string.quoted.single.address.zone_file"
     },
-    { "match": "([A-Za-z0-9_.-]*)\\s+(?:([0-9A-Za-z]*)\\s+)?([I|i][N|n]\\s+[A-Za-z]+)\\s+(.*)",
+    { "match": "([A-Za-z0-9_.-]*)\\s+(?:([0-9A-Za-z]*)\\s+)?([I|i][N|n]\\s+[A-Za-z0-9]+)\\s+(.*)",
         "name": "string.quoted.single.address.zone_file",
         "captures": {
             "2": { "name": "variable.other.timeunit.zone_file"},

--- a/Bind Zone Files.tmLanguage
+++ b/Bind Zone Files.tmLanguage
@@ -50,7 +50,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>([A-Za-z0-9_.-]*)\s+(?:([0-9A-Za-z]*)\s+)?([I|i][N|n]\s+[A-Za-z]+)\s+(.*)\(</string>
+			<string>([A-Za-z0-9_.-]*)\s+(?:([0-9A-Za-z]*)\s+)?([I|i][N|n]\s+[A-Za-z0-9]+)\s+(.*)\(</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>2</key>
@@ -103,7 +103,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>([A-Za-z0-9_.-]*)\s+(?:([0-9A-Za-z]*)\s+)?([I|i][N|n]\s+[A-Za-z]+)\s+(.*)</string>
+			<string>([A-Za-z0-9_.-]*)\s+(?:([0-9A-Za-z]*)\s+)?([I|i][N|n]\s+[A-Za-z0-9]+)\s+(.*)</string>
 			<key>name</key>
 			<string>string.quoted.single.address.zone_file</string>
 		</dict>


### PR DESCRIPTION
Now correctly highlights e.g. the TYPE257 which can be used as part of https://tools.ietf.org/html/rfc3597 for resource records unknown to particular DNS server software like the newer CAA records (my use case, see https://sslmate.com/caa/).